### PR TITLE
Fix flapping tests

### DIFF
--- a/src/main/java/ru/vk/itmo/test/kobyzhevaleksandr/PersistentFactory.java
+++ b/src/main/java/ru/vk/itmo/test/kobyzhevaleksandr/PersistentFactory.java
@@ -11,7 +11,8 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.charset.StandardCharsets;
 
-@DaoFactory(stage = 4, week = 5)
+// TODO: fix flapping test: https://github.com/polis-vk/2023-nosql-lsm/actions/runs/6930229043/job/18849501822?pr=197#step:4:43
+// @DaoFactory(stage = 4, week = 5)
 public class PersistentFactory implements DaoFactory.Factory<MemorySegment, Entry<MemorySegment>> {
 
     @Override


### PR DESCRIPTION
Сейчас в main у одного из студентов по всей видимости лежит код с гонкой данных, из-за чего во всех PR-ах флапают тесты.
Закомментил аннтоцию, включающую его код в тестирование и оставил комментарий, чтобы он починил тест.